### PR TITLE
Fix extraction bug in GeoSirene

### DIFF
--- a/GeoSirene/Program.cs
+++ b/GeoSirene/Program.cs
@@ -136,6 +136,7 @@ namespace GeoSirene
 
                     MemoryStream memoryStream = new MemoryStream();
                     entry.Extract(memoryStream);
+                    memoryStream.Position = 0;
 
                     using (FileStream file = new FileStream(Desnation + entry.FileName.ToString(), FileMode.Create, FileAccess.Write))
                     {


### PR DESCRIPTION
## Summary
- fix extraction logic to reset stream position before writing files

## Testing
- `dotnet build GeoSirene.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd7d7a6d0832c9d39c89aaf1d0066